### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const config = require("./config.js");
+const path = require("path");
 const serverless = require("serverless-http");
 const express = require("express");
 const { DynamoDBClient, PutItemCommand, GetItemCommand, ScanCommand } = require("@aws-sdk/client-dynamodb");
@@ -504,7 +505,12 @@ app
           try {
             await dynamoDb.send(new PutItemCommand(params));
             res.redirect(`/status/${req.file.filename}`);
-            if (fs.existsSync(req.file.path)) fs.unlinkSync(req.file.path);
+            const normalizedPath = path.resolve(req.file.path);
+            if (!normalizedPath.startsWith("/tmp/")) {
+              res.status(400).json({ error: "Invalid file path" });
+              return;
+            }
+            if (fs.existsSync(normalizedPath)) fs.unlinkSync(normalizedPath);
           } catch (error) {
             res.status(500).json({ error: "Could not create the job" });
           }


### PR DESCRIPTION
Potential fix for [https://github.com/logan-han/twitter-deleter/security/code-scanning/10](https://github.com/logan-han/twitter-deleter/security/code-scanning/10)

To address the issue, we need to ensure that the file path in `req.file.path` is confined to the `/tmp/` directory. This can be achieved by normalizing the path using `path.resolve` and verifying that it starts with the `/tmp/` directory. If the path is invalid or points outside the intended directory, the code should reject the request.

Steps to fix:
1. Import the `path` module if it is not already imported.
2. Normalize `req.file.path` using `path.resolve`.
3. Check that the normalized path starts with `/tmp/`. If not, return an error response.
4. Proceed with file operations only if the path is valid.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
